### PR TITLE
Unify transaction date & amount format parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ API Usage
 curl https://q5i6ef1jfi.execute-api.ap-southeast-1.amazonaws.com/api/upload -F 'file=@[path/to/file].pdf'
 
 # CSV upload, after user reviews & confirms parse & classification results
-curl -v https://q5i6ef1jfi42q6iw44o2.execute-api.ap-southeast-1.amazonaws.com/api/confirm -X POST -d 'uuid=[uuid]' -d 'file=@[path/to/file].csv'
+curl -v https://q5i6ef1jfi.execute-api.ap-southeast-1.amazonaws.com/api/confirm -X POST -d 'uuid=[uuid]' -d 'file=@[path/to/file].csv'
 
 # User transaction data fetch, returns a csv of all transaction data for the given uuid
-curl https://q5i6ef1jfi42q6iw44o2.execute-api.ap-southeast-1.amazonaws.com/api/transactions/[uuid]
+curl https://q5i6ef1jfi.execute-api.ap-southeast-1.amazonaws.com/api/transactions/[uuid]
 
 # Refresh model with new csv data
-curl -v https://q5i6ef1jfi42q6iw44o2.execute-api.ap-southeast-1.amazonaws.com/api/refresh-model
+curl -v https://q5i6ef1jfi.execute-api.ap-southeast-1.amazonaws.com/api/refresh-model
 ```
 
 Development

--- a/backend/app.py
+++ b/backend/app.py
@@ -110,7 +110,6 @@ def upload():
     s3.upload_file(filename, PDF_BUCKET, key_name)
 
     # parse
-    # TODO: parsing is slow, need to improve performance
     output = io.StringIO()
     csv_writer = csv.writer(output)
     csv_writer.writerow(['date', 'description', 'amount', 'foreign_amount',

--- a/cleaning/pdf-mining/test_pdftotxt.py
+++ b/cleaning/pdf-mining/test_pdftotxt.py
@@ -4,9 +4,10 @@ import io
 import difflib
 import os
 import time
+from datetime import datetime
 from glob import glob
 from pprint import pprint
-from pdftotxt import process_pdf
+from pdftotxt import process_pdf, parse_transaction_date
 
 SUPPORTED_BANKS = ['dbs', 'uob', 'ocbc', 'anz']
 
@@ -26,6 +27,15 @@ class TestPdftotxt(unittest.TestCase):
                 actual = f.readlines()
                 self.assertFalse(diff(expected, actual))
 
+
+    def test_parse_transaction_date(self):
+        statement_date = datetime(2016, 4, 1)
+        date = parse_transaction_date('24/03', statement_date)
+        self.assertEqual(date, '2016-03-24')
+
+        statement_date = datetime(2018, 1, 1)
+        date = parse_transaction_date('24/12', statement_date)
+        self.assertEqual(date, '2017-12-24')
 
 def diff(a, b):
     stripped_a = list(map(str.strip, a))


### PR DESCRIPTION
- both statement date and transaction date are now returned in the form of yyyy-mm-dd
- amount is returned as a float. Negative values indicate credit (e.g. income/refund)