### PR TITLE
Allow pdf password as a request parameter in /upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ API Usage
 ```
 # PDF upload, parse & classification, returns a csv or json
 # Use -H "Accept: application/json" header to control response format
-curl https://q5i6ef1jfi.execute-api.ap-southeast-1.amazonaws.com/api/upload -F 'file=@[path/to/file].pdf'
+curl https://q5i6ef1jfi.execute-api.ap-southeast-1.amazonaws.com/api/upload -F 'file=@[path/to/file].pdf' -F 'password=[pdf password]'
 
 # CSV upload, after user reviews & confirms parse & classification results
 curl -v https://q5i6ef1jfi.execute-api.ap-southeast-1.amazonaws.com/api/confirm -X POST -d 'uuid=[uuid]' -d 'file=@[path/to/file].csv'

--- a/backend/app.py
+++ b/backend/app.py
@@ -128,13 +128,17 @@ def upload():
     csv_writer.writerow(['date', 'description', 'amount', 'foreign_amount',
                          'statement_date'])
     app.log.debug('start parsing pdf')
-    pdftotxt.process_pdf(filename, csv_writer,
-                pdftotxt_bin=os.path.join(BIN_DIR, 'pdftotext'),
-                include_source=False,
-                password=password,
-                env=dict(LD_LIBRARY_PATH=LIB_DIR))
-    app.log.debug('done parsing pdf')
-    os.remove(filename)
+    try:
+        pdftotxt.process_pdf(filename, csv_writer,
+                    pdftotxt_bin=os.path.join(BIN_DIR, 'pdftotext'),
+                    include_source=False,
+                    password=password,
+                    env=dict(LD_LIBRARY_PATH=LIB_DIR))
+    except RuntimeError as e:
+        return Response(body=e.args[0], status_code=400)
+    finally:
+        app.log.debug('done parsing pdf')
+        os.remove(filename)
 
     # classification
     classifier = get_model(CLASSIFIER_FILENAME)[0]

--- a/backend/app.py
+++ b/backend/app.py
@@ -111,6 +111,7 @@ def dataframe_as_response(df, accept_header):
 def upload():
     form_data = get_multipart_data()
     form_file = form_data['file'][0]
+    password = form_data['password'][0] if 'password' in form_data else None
 
     with NamedTemporaryFile(mode='wb', suffix='.pdf', delete=False) as f:
         filename = f.name
@@ -130,6 +131,7 @@ def upload():
     pdftotxt.process_pdf(filename, csv_writer,
                 pdftotxt_bin=os.path.join(BIN_DIR, 'pdftotext'),
                 include_source=False,
+                password=password,
                 env=dict(LD_LIBRARY_PATH=LIB_DIR))
     app.log.debug('done parsing pdf')
     os.remove(filename)

--- a/cleaning/pdf-mining/pdftotxt.py
+++ b/cleaning/pdf-mining/pdftotxt.py
@@ -79,7 +79,7 @@ def peek_forward_for_currency(iterator, max_lines=2):
 
 
 def process_pdf(filename, csv_writer, pdftotxt_bin='pdftotext',
-                include_source=True, **kwargs):
+                include_source=True, password=None, **kwargs):
 
     # recursive fn
     def process_line(iterator, statement_date):
@@ -119,8 +119,11 @@ def process_pdf(filename, csv_writer, pdftotxt_bin='pdftotext',
             pass
 
     print(filename)
-    result = subprocess.run([pdftotxt_bin, '-layout', filename, '-'],
-                            stdout=subprocess.PIPE, **kwargs)
+    if password:
+        command = [pdftotxt_bin, '-layout', '-upw', password, filename, '-']
+    else:
+        command = [pdftotxt_bin, '-layout', filename, '-']
+    result = subprocess.run(command, stdout=subprocess.PIPE, **kwargs)
     lines = result.stdout.decode('utf-8').split('\n')
     statement_date = None
     process_line(iter(lines), statement_date)

--- a/cleaning/pdf-mining/test_pdftotxt.py
+++ b/cleaning/pdf-mining/test_pdftotxt.py
@@ -37,6 +37,25 @@ class TestPdftotxt(unittest.TestCase):
         date = parse_transaction_date('24/12', statement_date)
         self.assertEqual(date, '2017-12-24')
 
+    def test_process_pdf_with_password(self):
+        with open(f'data/uob.csv') as ef:
+            expected = list(map(lambda line: line.replace('uob.pdf',
+                                'uob_password.pdf'), ef.readlines()))
+        with io.StringIO() as f:
+            csv_writer = csv.writer(f)
+            process_pdf(f'./data/uob_password.pdf', csv_writer, password='123abc')
+            f.seek(0)
+            actual = f.readlines()
+            self.assertFalse(diff(expected, actual))
+
+    def test_process_pdf_with_wrong_password(self):
+        with io.StringIO() as f:
+            csv_writer = csv.writer(f)
+            with self.assertRaises(RuntimeError) as ex:
+                process_pdf(f'./data/uob_password.pdf', csv_writer, password='123')
+            self.assertEqual(ex.exception.args[0], 'Incorrect password')
+
+
 def diff(a, b):
     stripped_a = list(map(str.strip, a))
     stripped_b = list(map(str.strip, b))


### PR DESCRIPTION
For now, statements with password require password to be specified on every upload. After we add auth we can give user an option to save their password.